### PR TITLE
Update Quasar Repositories links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Head on to the official community forum: [http://forum.quasar-framework.org](htt
 
 ## Quasar Repositories
 
-* [Quasar Framework](https://github.com/rstoenescu/quasar-framework)
-* [Quasar CLI](https://github.com/rstoenescu/q-cli)
-* [Quasar Play App](https://github.com/rstoenescu/q-play)
+* [Quasar Framework](https://github.com/quasarframework/quasar)
+* [Quasar CLI](https://github.com/quasarframework/quasar-cli)
+* [Quasar Play App](https://github.com/quasarframework/quasar-play)
 
 ## Contributing
 


### PR DESCRIPTION
Links in README.md lead to old, non-existent repositories.
