### PR TITLE
Fix issue with spinner never stopping

### DIFF
--- a/src/components/showcase/scrolling/infinite-scroll.vue
+++ b/src/components/showcase/scrolling/infinite-scroll.vue
@@ -12,8 +12,8 @@
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
         </p>
 
-        <div class="row justify-center" style="margin-bottom: 50px;">
-          <q-spinner-dots slot="message" :size="40" />
+        <div slot="message" class="row justify-center" style="margin-bottom: 50px;">
+          <q-spinner-dots :size="40" />
         </div>
       </q-infinite-scroll>
     </div>


### PR DESCRIPTION
I was experiencing [the same issue as reported here](https://github.com/quasarframework/quasar/issues/888), and learned that the slot="message" attribute needs to be moved upwards to the highest div parent of the spinner, for it to work as expected. The slot="message" attribute should only be part of the q-spinner tag if it is not enclosed in a parent div.

Would be nice to have this also reflected here in the play demo/documentation.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
