### PR TITLE
chore: Fix Docs link

### DIFF
--- a/src/pages/landing.vue
+++ b/src/pages/landing.vue
@@ -52,7 +52,7 @@ export default {
   },
   methods: {
     launch () {
-      openURL('http://beta.quasar-framework.org')
+      openURL('http://www.quasar-framework.org')
     },
     viewPrivacyPolicy () {
       this.$refs.privacy.show()

--- a/src/pages/landing.vue
+++ b/src/pages/landing.vue
@@ -52,7 +52,7 @@ export default {
   },
   methods: {
     launch () {
-      openURL('http://www.quasar-framework.org')
+      openURL('http://quasar-framework.org')
     },
     viewPrivacyPolicy () {
       this.$refs.privacy.show()


### PR DESCRIPTION
Fix "Quasar Docs" broken link: from `beta.quasar-framework.org` to `www.quasar-framework.org`.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe: Fix broken link

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.