### PR TITLE
Remove unused property in autocomplete.vue

### DIFF
--- a/src/pages/showcase/forms/autocomplete.vue
+++ b/src/pages/showcase/forms/autocomplete.vue
@@ -123,7 +123,6 @@ export default {
   data () {
     return {
       terms: '',
-      terms2: '',
       countries: parseCountries(),
       chips1: ['Romania', 'Algeria'],
       chips2: ['Bahamas', 'Costa Rica']


### PR DESCRIPTION
I removed the unused `terms2` property which have been added (i don't know why) in one of the last commits